### PR TITLE
Firefox fix for vertical center of determiner and connector

### DIFF
--- a/src/components/Title/Title.js
+++ b/src/components/Title/Title.js
@@ -59,7 +59,7 @@ export default function Title({
   setCategory,
 }) {
   return (
-    <div className="mx-4 flex text-3xl flex-row flex-wrap justify-center gap-3 items-baseline">
+    <div className="mx-4 flex text-3xl flex-row flex-wrap justify-center gap-3 items-center">
       <p>{makeDeterminer(roadType)}</p>
       <FormControl variant="standard">
         <Select


### PR DESCRIPTION
The title interaction was rendering disaligned:
<img width="439" alt="screenshot 2022-05-04 at 12 40 23" src="https://user-images.githubusercontent.com/1041/166674847-14f9a613-1eba-438b-aaaa-ce461f1e0bc6.png">

On further analysis, the error only occured on Firefox, which seems to calculate its baseline different from WebKit/Blink rendering engines.
A fix implementing flexbox's vertical centering on all browsers was added with a Tailwind's class.

Good work on the project!